### PR TITLE
Replace rclone with Python crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ Navigate to your installation directory and open a terminal, run the bot with `n
 Enjoy 👍
 
 ## Myrient Index and Download Tips
-This bot can use the open directory at [Myrient](https://myrient.erista.me/) to fetch download links. Because the site does not provide search, run `scripts/update_myrient_index.py` to build a local index of all files. The script requires `rclone` and network access. The generated file is stored at `data/myrient_index.txt`.
+This bot can use the open directory at [Myrient](https://myrient.erista.me/) to fetch download links. Because the site does not provide search, run `scripts/update_myrient_index.py` to build a local index of all files. The script crawls the site using Python and requires network access. The generated file is stored at `data/myrient_index.txt`.
 
 Large files can be downloaded with any of the managers recommended on Myrient's wiki:
 
 - DownThemAll (recommended)
-- rclone HTTP remote
 - JDownloader or Motrix
 - aria2 or wget

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aiohttp
 beautifulsoup4
 rapidfuzz
 playwright
+requests

--- a/scripts/update_myrient_index.py
+++ b/scripts/update_myrient_index.py
@@ -1,34 +1,22 @@
 #!/usr/bin/env python3
 """Utility to update the local Myrient file index.
 
-This script uses `rclone` with the HTTP remote to recursively list all files
-from the Myrient open directory. The output is written to `data/myrient_index.txt`.
-`rclone` must be installed and network access allowed.
+This script crawls the Myrient open directory using Python code (no `rclone`
+required) and writes the results to `data/myrient_index.txt`.
 """
 
 import os
-import subprocess
+import sys
 
-BASE_URL = "https://myrient.erista.me/files/"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
-INDEX_PATH = os.path.join(ROOT_DIR, "data", "myrient_index.txt")
+sys.path.insert(0, ROOT_DIR)
+
+from scrapers.myrient import update_index
 
 
 def main() -> None:
-    os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
-    cmd = [
-        "rclone",
-        "lsf",
-        "-R",
-        "--http-url",
-        BASE_URL,
-        ":http:",
-    ]
-    print("Updating Myrient index. This may take a while...")
-    with open(INDEX_PATH, "w", encoding="utf-8") as f:
-        subprocess.check_call(cmd, stdout=f)
-    print(f"Index written to {INDEX_PATH}")
+    update_index()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop rclone usage for Myrient index updates
- add a Python based crawler in `scrapers/myrient.py`
- update helper script to call the crawler
- document the change in the README
- add `requests` to requirements

## Testing
- `python -m py_compile scrapers/myrient.py scripts/update_myrient_index.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687587788cd88332a4cc0ece7d13ad51