### PR TITLE
Handle missing rapidfuzz dependency

### DIFF
--- a/scrapers/fuzz_fallback.py
+++ b/scrapers/fuzz_fallback.py
@@ -1,0 +1,20 @@
+"""Wrapper for fuzzy matching with a fallback implementation."""
+try:
+    from rapidfuzz import fuzz  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handle missing optional dependency
+    import difflib
+
+    class _FallbackFuzz:
+        """Minimal replacement for ``rapidfuzz.fuzz``.
+
+        Only implements ``WRatio`` which returns a score in the range 0-100.
+        """
+
+        @staticmethod
+        def WRatio(a: str, b: str) -> float:
+            # difflib.SequenceMatcher returns 0..1; scale to 0..100
+            return difflib.SequenceMatcher(None, a, b).ratio() * 100
+
+    fuzz = _FallbackFuzz()
+
+__all__ = ["fuzz"]

--- a/scrapers/gog_games.py
+++ b/scrapers/gog_games.py
@@ -1,6 +1,7 @@
 import urllib.parse
 from bs4 import BeautifulSoup
-from rapidfuzz import fuzz
+# Attempt to use rapidfuzz for fast fuzzy matching but fall back to difflib
+from scrapers.fuzz_fallback import fuzz
 from playwright.async_api import async_playwright
 
 BASE_URL = "https://gog-games.to"

--- a/scrapers/myrient.py
+++ b/scrapers/myrient.py
@@ -4,7 +4,8 @@ import urllib.parse
 
 import requests
 from bs4 import BeautifulSoup
-from rapidfuzz import fuzz
+# Attempt to use rapidfuzz for fast fuzzy matching but fall back to difflib
+from scrapers.fuzz_fallback import fuzz
 
 BASE_URL = "https://myrient.erista.me/files"
 

--- a/scrapers/romspure.py
+++ b/scrapers/romspure.py
@@ -5,7 +5,8 @@ import urllib.parse
 from bs4 import BeautifulSoup
 
 # We do fuzzy matching for the game name within the search results
-from rapidfuzz import fuzz
+# Attempt to use rapidfuzz for fast fuzzy matching but fall back to difflib
+from scrapers.fuzz_fallback import fuzz
 
 # Import the dictionary-based function from platform_map
 from scrapers.platform_map import get_romspure_subpath_exact


### PR DESCRIPTION
## Summary
- add `scrapers/fuzz_fallback.py` that uses rapidfuzz when available
- use the fallback module in all scrapers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/update_myrient_index.py --help` *(fails: KeyboardInterrupt after starting network requests)*

------
https://chatgpt.com/codex/tasks/task_e_687597f0c6cc8332a5f30a65466b01fe