### PR TITLE
Fix Myrient URL encoding

### DIFF
--- a/scrapers/myrient.py
+++ b/scrapers/myrient.py
@@ -213,7 +213,7 @@ async def search_myrient(game_title: str, platform_name: str) -> list[str]:
         fname = os.path.basename(entry)
         score = fuzz.WRatio(fname.lower(), game_title.lower())
         if score >= THRESHOLD:
-            encoded_path = urllib.parse.quote(entry, safe="/ ")
+            encoded_path = urllib.parse.quote(entry, safe="/")
             url = f"{BASE_URL}/{encoded_path}"
             candidates.append((score, url, fname))
 


### PR DESCRIPTION
## Summary
- encode spaces in Myrient URLs so they render correctly in Discord

## Testing
- `python -m py_compile scrapers/myrient.py`


------
https://chatgpt.com/codex/tasks/task_e_6876a6f7337c83328428bfbee1daa787