### PR TITLE
Handle PlayStation aliases

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -276,9 +276,14 @@ async def play_command(interaction: Interaction, title: str):
         # 4) Aggregator: Get download links from GOG and/or RomsPure
         dl_links = await get_all_download_links(title_text, platform_str)
         if dl_links:
-            link_text = "\n".join(
-                f"[{title_text} at {source}]({url})" for source, url in dl_links
-            )
+            link_lines = []
+            for source, url in dl_links:
+                if source == "Myrient":
+                    line = f"[Direct Download from myrient.erista.me]({url})"
+                else:
+                    line = f"[{title_text} at {source}]({url})"
+                link_lines.append(line)
+            link_text = "\n".join(link_lines)
             embed.add_field(name="Download Links", value=link_text, inline=False)
         else:
             embed.add_field(name="Download Links", value="No links found", inline=False)

--- a/scrapers/myrient.py
+++ b/scrapers/myrient.py
@@ -7,6 +7,7 @@ import requests
 from bs4 import BeautifulSoup
 # Attempt to use rapidfuzz for fast fuzzy matching but fall back to difflib
 from scrapers.fuzz_fallback import fuzz
+from scrapers.platform_map import canonicalize_platform_name
 
 BASE_URL = "https://myrient.erista.me/files"
 
@@ -179,7 +180,8 @@ MYRIENT_PLATFORM_MAP = {
 THRESHOLD = 70
 
 def get_myrient_subpath_exact(platform_name: str) -> str | None:
-    return MYRIENT_PLATFORM_MAP.get(platform_name)
+    canonical = canonicalize_platform_name(platform_name)
+    return MYRIENT_PLATFORM_MAP.get(canonical)
 
 
 def _load_index() -> list[str]:

--- a/scrapers/platform_map.py
+++ b/scrapers/platform_map.py
@@ -31,9 +31,40 @@ ROMSPURE_PLATFORM_MAP = {
     "Microsoft Xbox 360": "microsoft-xbox-360",
 }
 
+# -------------------------------------------------------------------------
+# Platform name canonicalization
+# -------------------------------------------------------------------------
+# Map of lowercase aliases to their canonical TheGamesDB platform names
+PLATFORM_SYNONYMS = {
+    "sony playstation": "Sony PlayStation",
+    "playstation": "Sony PlayStation",
+    "ps1": "Sony PlayStation",
+    "psx": "Sony PlayStation",
+    "sony playstation 2": "Sony PlayStation 2",
+    "playstation 2": "Sony PlayStation 2",
+    "ps2": "Sony PlayStation 2",
+    "sony playstation 3": "Sony Playstation 3",
+    "playstation 3": "Sony Playstation 3",
+    "ps3": "Sony Playstation 3",
+    "sony playstation 4": "Sony Playstation 4",
+    "playstation 4": "Sony Playstation 4",
+    "ps4": "Sony Playstation 4",
+    "sony playstation vita": "Sony Playstation Vita",
+    "playstation vita": "Sony Playstation Vita",
+    "psvita": "Sony Playstation Vita",
+}
+
+_PLATFORM_SYNONYMS_LOWER = {k.lower(): v for k, v in PLATFORM_SYNONYMS.items()}
+
+def canonicalize_platform_name(name: str) -> str:
+    """Return the canonical platform name for lookups."""
+    return _PLATFORM_SYNONYMS_LOWER.get(name.lower(), name)
+
 def get_romspure_subpath_exact(platform_name: str) -> str | None:
     """
     Returns the romspure subpath for the given TheGamesDB platform name.
+    Handles common aliases via canonicalize_platform_name().
     If there is no exact match, returns None.
     """
-    return ROMSPURE_PLATFORM_MAP.get(platform_name)
+    canonical = canonicalize_platform_name(platform_name)
+    return ROMSPURE_PLATFORM_MAP.get(canonical)


### PR DESCRIPTION
## Summary
- map common PlayStation aliases so Romspure and Myrient lookups succeed
- tweak Myrient embed link text

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6876aab398d88332b2d7769fe59dd7c8