### PR TITLE
Fix exact platform matching for search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ Large files can be downloaded with any of the managers recommended on Myrient's 
 - DownThemAll (recommended)
 - JDownloader or Motrix
 - aria2 or wget
+- Searches restrict matches to the exact console directory to avoid cross-platform results

--- a/scrapers/myrient.py
+++ b/scrapers/myrient.py
@@ -221,8 +221,9 @@ async def search_myrient(game_title: str, platform_name: str) -> list[str]:
         return []
 
     candidates = []
+    prefix = subpath.rstrip("/") + "/"
     for entry in index:
-        if not entry.startswith(subpath):
+        if not entry.startswith(prefix):
             continue
         fname = os.path.basename(entry)
         score = fuzz.WRatio(fname.lower(), game_title.lower())

--- a/scrapers/romspure.py
+++ b/scrapers/romspure.py
@@ -50,8 +50,13 @@ async def search_romspure(game_title: str, platform_name: str) -> list[str]:
             continue
 
         detail_url = a_tag.get("href")
-        # Ensure the final link actually has our subpath -> skip if it's the wrong subpath
-        if subpath not in detail_url:
+        # Ensure the final link has the exact subpath
+        if detail_url:
+            path = urllib.parse.urlparse(detail_url).path
+            expect = f"/roms/{subpath}/"
+            if not path.startswith(expect):
+                continue
+        else:
             continue
 
         # The displayed name is typically in <h3 class="h6 font-weight-semibold">


### PR DESCRIPTION
## Summary
- avoid partial prefix matches when looking through Myrient index
- check RomsPure URLs for the exact platform subpath
- document the change in the README

## Testing
- `python -m py_compile scrapers/myrient.py scrapers/romspure.py`
- `pip install -q -r requirements.txt`
- `python -m py_compile scrapers/myrient.py scrapers/romspure.py`
- `python - <<'EOF'
from scrapers.platform_map import get_romspure_subpath_exact
print('PS1 ->', get_romspure_subpath_exact('Sony PlayStation'))
print('PS2 ->', get_romspure_subpath_exact('Sony PlayStation 2'))
EOF`
- `python - <<'EOF'
from scrapers import myrient
myrient._index_cache = ['Redump/Sony - PlayStation Portable/Ape Escape - On the Loose (USA).zip', 'Redump/Sony - PlayStation/Ape Escape (USA).zip']
import asyncio
async def main():
    links = await myrient.search_myrient('Ape Escape', 'Sony PlayStation')
    print('Links:', links)
asyncio.run(main())
EOF`
  - expected: correct PlayStation result
- `python - <<'EOF'
from scrapers.romspure import search_romspure
import asyncio
async def main():
    links = await search_romspure('Metal Gear Solid', 'Sony PlayStation')
    print(links[:3])
asyncio.run(main())
EOF` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6876bdde05048332945b3a54929c7ca6