### PR TITLE
Fix Nintendo platform matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Large files can be downloaded with any of the managers recommended on Myrient's 
 - JDownloader or Motrix
 - aria2 or wget
 - Searches restrict matches to the exact console directory to avoid cross-platform results
+- Common aliases like "PS2" or "N64" are recognized automatically

--- a/scrapers/platform_map.py
+++ b/scrapers/platform_map.py
@@ -52,6 +52,13 @@ PLATFORM_SYNONYMS = {
     "sony playstation vita": "Sony Playstation Vita",
     "playstation vita": "Sony Playstation Vita",
     "psvita": "Sony Playstation Vita",
+    # Common Nintendo aliases
+    "nintendo gamecube": "Nintendo GameCube",
+    "gamecube": "Nintendo GameCube",
+    "game cube": "Nintendo GameCube",
+    "nintendo 64": "Nintendo 64",  # allow lowercase normalization
+    "n64": "Nintendo 64",
+    "nintendo n64": "Nintendo 64",
 }
 
 _PLATFORM_SYNONYMS_LOWER = {k.lower(): v for k, v in PLATFORM_SYNONYMS.items()}


### PR DESCRIPTION
## Summary
- allow common Nintendo aliases like `N64` and `Gamecube`
- mention recognized aliases in README

## Testing
- `ruff .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c7c6c0a08332a45ed2e1e7425e59