### PR TITLE
Add EmulatorJS server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You need an API key which you can acquire for free here `https://www.mobygames.c
 
 ## Config.json
 Either clone the repository or download as a zip.  
-Open `config.json` and enter your Bot Token, Guild ID, MobyGames API Key, and Owner ID (Discord name)
+Open `config.json` and enter your Bot Token, Guild ID, MobyGames API Key, and Owner ID (Discord name).
+Optionally set `emulatorJsBaseUrl` to the base URL of your EmulatorJS server if you want **Play Now** links.
 
 ## Bot.js
 Download and Install Node.js  
@@ -47,3 +48,9 @@ Large files can be downloaded with any of the managers recommended on Myrient's 
 - Common aliases like "PS2" or "N64" are recognized automatically
 - N64 titles are stored in the "BigEndian" set and GameCube uses the NKit RVZ collection
 - If a game spans multiple discs, download links for each disc are returned
+
+## EmulatorJS Play-Now
+To enable the optional **Play Now** links, export your EmulatorJS frontend game lists using `scripts/update_emulatorjs_index.py`.
+The script expects the path to your container's `/emulatorjs/frontend` directory and stores the results in `data/emulatorjs_index.json`.
+Add an `emulatorJsBaseUrl` entry to `config.json` pointing at your server (for example `http://blackbox:81/#`).
+When the value is blank, Play Now links are disabled. When set and a matching title is found, the bot includes a **Play Now** link in the embed.

--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
 	"guildId": "",
     "theGamesDbApiKey": "",
     "prefix": "!",
-    "ownerID": ""
+    "ownerID": "",
+    "emulatorJsBaseUrl": ""
 }

--- a/scrapers/emulatorjs.py
+++ b/scrapers/emulatorjs.py
@@ -1,0 +1,97 @@
+# scrapers/emulatorjs.py
+"""Lookup game titles in a local EmulatorJS index and build Play Now links."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List
+
+from scrapers.fuzz_fallback import fuzz
+from scrapers.platform_map import canonicalize_platform_name
+
+# Environment variable for the base URL used to build play links
+# Can be overridden at runtime via :func:`set_base_url`.
+BASE_URL: str | None = os.environ.get("EMULATORJS_BASE_URL")
+
+
+def set_base_url(url: str | None) -> None:
+    """Override :data:`BASE_URL` with a value from configuration."""
+    global BASE_URL
+    BASE_URL = url
+
+# Path to the JSON index generated via scripts/update_emulatorjs_index.py
+INDEX_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "emulatorjs_index.json")
+
+# Mapping of TheGamesDB platform names to EmulatorJS short codes
+EMULATORJS_PLATFORM_MAP: Dict[str, str] = {
+    "Nintendo Game Boy": "gb",
+    "Nintendo Game Boy Color": "gbc",
+    "Nintendo Game Boy Advance": "gba",
+    "Nintendo Entertainment System": "nes",
+    "Super Nintendo (SNES)": "snes",
+    "Super Nintendo Entertainment System": "snes",
+    "Nintendo 64": "n64",
+    "Sega Genesis": "segaMD",
+    "Sega Mega Drive - Genesis": "segaMD",
+    "Sega Mega Drive": "segaMD",
+    "Sony PlayStation": "psx",
+}
+
+_index_cache: Dict[str, List[str]] | None = None
+
+
+def _load_index() -> Dict[str, List[str]]:
+    """Load the index from ``INDEX_PATH`` once and cache it."""
+    global _index_cache
+    if _index_cache is not None:
+        return _index_cache
+
+    if os.path.isfile(INDEX_PATH):
+        with open(INDEX_PATH, "r", encoding="utf-8") as f:
+            _index_cache = json.load(f)
+    else:
+        print(f"[emulatorjs] index file not found at {INDEX_PATH}")
+        _index_cache = {}
+
+    return _index_cache
+
+
+def _get_code(platform_name: str) -> str | None:
+    canonical = canonicalize_platform_name(platform_name)
+    return EMULATORJS_PLATFORM_MAP.get(canonical)
+
+
+async def search_emulatorjs(game_title: str, platform_name: str) -> str | None:
+    """Return a Play Now URL if a match is found."""
+    if not BASE_URL:
+        return None
+    code = _get_code(platform_name)
+    if code is None:
+        print(f"[emulatorjs] no code for platform '{platform_name}'")
+        return None
+
+    index = _load_index().get(code, [])
+    if not index:
+        return None
+
+    best_idx: int | None = None
+    best_score = -1
+    for idx, title in enumerate(index):
+        score = fuzz.WRatio(title.lower(), game_title.lower())
+        if score > best_score:
+            best_idx = idx
+            best_score = score
+
+    if best_idx is None or best_score < 70:
+        return None
+
+    # EmulatorJS URLs use 1-based numbering in the fragment
+    return f"{BASE_URL}{code}---{best_idx + 1}"
+
+
+def get_emulatorjs_play_url(game_title: str, platform_name: str) -> str | None:
+    """Synchronous wrapper for :func:`search_emulatorjs`."""
+    import asyncio
+
+    return asyncio.run(search_emulatorjs(game_title, platform_name))

--- a/scripts/update_emulatorjs_index.py
+++ b/scripts/update_emulatorjs_index.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Generate the EmulatorJS game index used for Play Now links."""
+
+import json
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(SCRIPT_DIR)
+sys.path.insert(0, ROOT_DIR)
+
+from scrapers.emulatorjs import INDEX_PATH, EMULATORJS_PLATFORM_MAP
+
+
+def _collect_titles(frontend_dir: str) -> dict[str, list[str]]:
+    """Return a mapping of system code to list of titles."""
+    result: dict[str, list[str]] = {}
+    data_dir = os.path.join(frontend_dir, "data")
+    for code in EMULATORJS_PLATFORM_MAP.values():
+        path = os.path.join(data_dir, code, "index.json")
+        if not os.path.isfile(path):
+            continue
+        with open(path, "r", encoding="utf-8") as f:
+            try:
+                entries = json.load(f)
+            except json.JSONDecodeError:
+                print(f"[emulatorjs] could not parse {path}")
+                continue
+        titles: list[str] = []
+        for item in entries:
+            title = (
+                item.get("title")
+                or item.get("name")
+                or item.get("slug")
+                or ""
+            )
+            if title:
+                titles.append(title)
+        if titles:
+            result[code] = titles
+    return result
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: update_emulatorjs_index.py <path_to_frontend>")
+        sys.exit(1)
+
+    frontend_dir = sys.argv[1]
+    index = _collect_titles(frontend_dir)
+    os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
+    with open(INDEX_PATH, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2)
+    print(f"[emulatorjs] wrote index for {len(index)} systems to {INDEX_PATH}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- expose `emulatorJsBaseUrl` in `config.json`
- configure bot to use the URL and skip EmulatorJS lookups when blank
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6877303edfac8332ac93f959c14524b1