### PR TITLE
Update EmulatorJS index script for local configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Large files can be downloaded with any of the managers recommended on Myrient's 
 - If a game spans multiple discs, download links for each disc are returned
 
 ## EmulatorJS Play-Now
-To enable the optional **Play Now** links, export your EmulatorJS frontend game lists using `scripts/update_emulatorjs_index.py`.
-The script expects the path to your container's `/emulatorjs/frontend` directory and stores the results in `data/emulatorjs_index.json`.
+To enable the optional **Play Now** links, export your EmulatorJS system config files and place them next to `scripts/update_emulatorjs_index.py` (or pass the directory as an argument). Run `scripts/update_emulatorjs_index.py` to create `data/emulatorjs_index.json`.
 Add an `emulatorJsBaseUrl` entry to `config.json` pointing at your server (for example `http://blackbox:81/#`).
 When the value is blank, Play Now links are disabled. When set and a matching title is found, the bot includes a **Play Now** link in the embed.

--- a/scrapers/emulatorjs.py
+++ b/scrapers/emulatorjs.py
@@ -36,6 +36,7 @@ EMULATORJS_PLATFORM_MAP: Dict[str, str] = {
     "Sega Mega Drive - Genesis": "segaMD",
     "Sega Mega Drive": "segaMD",
     "Sony PlayStation": "psx",
+    "3DO Interactive Multiplayer": "3do",
 }
 
 _index_cache: Dict[str, List[str]] | None = None

--- a/scrapers/platform_map.py
+++ b/scrapers/platform_map.py
@@ -52,6 +52,9 @@ PLATFORM_SYNONYMS = {
     "sony playstation vita": "Sony Playstation Vita",
     "playstation vita": "Sony Playstation Vita",
     "psvita": "Sony Playstation Vita",
+    # 3DO
+    "3do": "3DO Interactive Multiplayer",
+    "3do interactive multiplayer": "3DO Interactive Multiplayer",
     # Common Nintendo aliases
     "nintendo gamecube": "Nintendo GameCube",
     "gamecube": "Nintendo GameCube",

--- a/scripts/update_emulatorjs_index.py
+++ b/scripts/update_emulatorjs_index.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Generate the EmulatorJS game index used for Play Now links."""
+"""Generate the EmulatorJS game index used for Play Now links.
+
+The script looks for JSON config files where each file represents a system.
+All ``*.json`` files in the given directory (or the script's own directory if
+no path is supplied) are parsed. Each JSON file should contain an ``items``
+object mapping game titles to their configuration. The filename without the
+extension is used as the system's short code.
+"""
 
 import json
 import os
@@ -9,45 +16,42 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
 sys.path.insert(0, ROOT_DIR)
 
-from scrapers.emulatorjs import INDEX_PATH, EMULATORJS_PLATFORM_MAP
+from scrapers.emulatorjs import INDEX_PATH
 
 
-def _collect_titles(frontend_dir: str) -> dict[str, list[str]]:
+def _collect_titles(config_dir: str) -> dict[str, list[str]]:
     """Return a mapping of system code to list of titles."""
     result: dict[str, list[str]] = {}
-    data_dir = os.path.join(frontend_dir, "data")
-    for code in EMULATORJS_PLATFORM_MAP.values():
-        path = os.path.join(data_dir, code, "index.json")
+    for name in sorted(os.listdir(config_dir)):
+        if not name.endswith(".json"):
+            continue
+        code = os.path.splitext(name)[0]
+        path = os.path.join(config_dir, name)
         if not os.path.isfile(path):
             continue
         with open(path, "r", encoding="utf-8") as f:
             try:
-                entries = json.load(f)
+                data = json.load(f)
             except json.JSONDecodeError:
                 print(f"[emulatorjs] could not parse {path}")
                 continue
-        titles: list[str] = []
-        for item in entries:
-            title = (
-                item.get("title")
-                or item.get("name")
-                or item.get("slug")
-                or ""
-            )
-            if title:
-                titles.append(title)
-        if titles:
-            result[code] = titles
+        items = data.get("items")
+        if isinstance(items, dict):
+            titles = list(items.keys())
+            if titles:
+                result[code] = titles
+        else:
+            print(f"[emulatorjs] no items found in {path}")
     return result
 
 
 def main() -> None:
-    if len(sys.argv) != 2:
-        print("Usage: update_emulatorjs_index.py <path_to_frontend>")
+    if len(sys.argv) > 2:
+        print("Usage: update_emulatorjs_index.py [path_to_configs]")
         sys.exit(1)
 
-    frontend_dir = sys.argv[1]
-    index = _collect_titles(frontend_dir)
+    config_dir = sys.argv[1] if len(sys.argv) == 2 else SCRIPT_DIR
+    index = _collect_titles(config_dir)
     os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
     with open(INDEX_PATH, "w", encoding="utf-8") as f:
         json.dump(index, f, indent=2)


### PR DESCRIPTION
## Summary
- scan `.json` files for titles when creating EmulatorJS index
- allow Play Now links for 3DO systems
- clarify instructions for building the index

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68773769f51c8332bfa00adedff27c2b