### PR TITLE
Fix emulatorjs async usage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -203,7 +203,7 @@ async def get_all_download_links(game_title: str, platform_name: str) -> list[tu
         for url, disc in myrient_links:
             links.append(("Myrient", url, disc))
 
-        play_url = get_emulatorjs_play_url(game_title, platform_name)
+        play_url = await get_emulatorjs_play_url(game_title, platform_name)
         if play_url:
             links.append(("PlayNow", play_url, None))
 

--- a/scrapers/emulatorjs.py
+++ b/scrapers/emulatorjs.py
@@ -91,8 +91,7 @@ async def search_emulatorjs(game_title: str, platform_name: str) -> str | None:
     return f"{BASE_URL}{code}---{best_idx + 1}"
 
 
-def get_emulatorjs_play_url(game_title: str, platform_name: str) -> str | None:
-    """Synchronous wrapper for :func:`search_emulatorjs`."""
-    import asyncio
+async def get_emulatorjs_play_url(game_title: str, platform_name: str) -> str | None:
+    """Asynchronous wrapper for :func:`search_emulatorjs`."""
 
-    return asyncio.run(search_emulatorjs(game_title, platform_name))
+    return await search_emulatorjs(game_title, platform_name)


### PR DESCRIPTION
## Summary
- avoid calling `asyncio.run()` inside running event loop
- make `get_emulatorjs_play_url` async and await it

## Testing
- `python3 -m py_compile bot.py scrapers/*.py scripts/*.py idle.py install.py reset_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_6877e3f1ee848332b899a6e0b00de4a4