### PR TITLE
Fix EmulatorJS play links

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,11 @@ from bs4 import BeautifulSoup
 from scrapers.gog_games import get_gog_download_links
 from scrapers.romspure import get_romspure_download_links
 from scrapers.myrient import get_myrient_download_links
-from scrapers.emulatorjs import get_emulatorjs_play_url, set_base_url as set_emulatorjs_base_url
+from scrapers.emulatorjs import (
+    get_emulatorjs_play_url,
+    set_base_url as set_emulatorjs_base_url,
+    BASE_DOMAIN as EMULATORJS_BASE_DOMAIN,
+)
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 config_path = os.path.join(script_dir, "config.json")
@@ -298,7 +302,9 @@ async def play_command(interaction: Interaction, title: str):
                 title_str = f"Direct Download {title_text}{disc_label} from myrient.erista.me"
                 direct_lines.append(f"[{title_str}]({url})")
             elif source == "PlayNow":
-                play_now_lines.append(f"[Play {title_text} now]({url})")
+                play_now_lines.append(
+                    f"[Play {title_text} at {EMULATORJS_BASE_DOMAIN}]({url})"
+                )
             elif source == "RomsPure":
                 site_lines.append(f"[{title_text} at romspure.cc]({url})")
             else:

--- a/scrapers/emulatorjs.py
+++ b/scrapers/emulatorjs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 from typing import Dict, List
+from urllib.parse import urlparse
 
 from scrapers.fuzz_fallback import fuzz
 from scrapers.platform_map import canonicalize_platform_name
@@ -13,12 +14,27 @@ from scrapers.platform_map import canonicalize_platform_name
 # Environment variable for the base URL used to build play links
 # Can be overridden at runtime via :func:`set_base_url`.
 BASE_URL: str | None = os.environ.get("EMULATORJS_BASE_URL")
+# Domain extracted from :data:`BASE_URL` for display purposes
+BASE_DOMAIN: str | None = None
 
 
 def set_base_url(url: str | None) -> None:
-    """Override :data:`BASE_URL` with a value from configuration."""
-    global BASE_URL
+    """Override :data:`BASE_URL` with a value from configuration.
+
+    If ``url`` is provided, ensure it ends with a ``#`` so play links are
+    constructed correctly and extract the domain for display purposes.
+    """
+    global BASE_URL, BASE_DOMAIN
+    if url:
+        if not url.endswith("#"):
+            url = url.rstrip("/") + "/#"
+        BASE_DOMAIN = urlparse(url).netloc
+    else:
+        BASE_DOMAIN = None
     BASE_URL = url
+
+# Sanitize any value from the environment at import time
+set_base_url(BASE_URL)
 
 # Path to the JSON index generated via scripts/update_emulatorjs_index.py
 INDEX_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "emulatorjs_index.json")


### PR DESCRIPTION
## Summary
- ensure EmulatorJS base URL ends with '#'
- extract base domain for nicer hyperlink text
- show domain only in Play Now links

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877f77243608332a6bef22a186b31ed