### PR TITLE
Improve handling of Myrient index

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Enjoy 👍
 
 ## Myrient Index and Download Tips
 This bot can use the open directory at [Myrient](https://myrient.erista.me/) to fetch download links. Because the site does not provide search, run `scripts/update_myrient_index.py` to build a local index of all files. The script crawls the site using Python and requires network access. The generated file is stored at `data/myrient_index.txt`.
-If a crawl is interrupted, rerunning the script will prompt you to resume from the last saved location or start over.
+If a crawl is interrupted, rerunning the script will prompt you to resume from the last saved location or start over. If the index file ends up empty (e.g., due to an interrupted crawl), delete it and run the script again so Myrient links appear correctly.
 
 Large files can be downloaded with any of the managers recommended on Myrient's wiki:
 

--- a/scrapers/myrient.py
+++ b/scrapers/myrient.py
@@ -204,8 +204,11 @@ def _load_index() -> list[str]:
     global _index_cache
     if _index_cache is not None:
         return _index_cache
-    if not os.path.isfile(INDEX_PATH):
-        print(f"[myrient] index file not found at {INDEX_PATH}. Run scripts/update_myrient_index.py to create it.")
+    if not os.path.isfile(INDEX_PATH) or os.path.getsize(INDEX_PATH) == 0:
+        print(
+            f"[myrient] index file not found or empty at {INDEX_PATH}. "
+            "Run scripts/update_myrient_index.py to create it."
+        )
         _index_cache = []
     else:
         with open(INDEX_PATH, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- warn when the local Myrient index file is empty
- document how to recover from an empty Myrient index

## Testing
- `python3 -m py_compile scrapers/myrient.py bot.py scripts/update_myrient_index.py scrapers/emulatorjs.py`

------
https://chatgpt.com/codex/tasks/task_e_687806100fcc83329182654915e8b135